### PR TITLE
プライバシーマニフェスト対応

### DIFF
--- a/SpeechStorage/PrivacyInfo.xcprivacy
+++ b/SpeechStorage/PrivacyInfo.xcprivacy
@@ -6,26 +6,12 @@
     <array>
         <dict>
             <key>NSPrivacyAccessedAPIType</key>
-            <string>NSSpeechSynthesisUsageDescription</string>
-            <key>NSPrivacyAccessedAPITypeReasons</key>
-            <array>
-                <string>SPE.1</string>
-            </array>
-        </dict>
-        <dict>
-            <key>NSPrivacyAccessedAPIType</key>
             <string>NSUserDefaults</string>
             <key>NSPrivacyAccessedAPITypeReasons</key>
             <array>
-                <string>UDE.1</string>
+                <string>CA92.1</string>
             </array>
         </dict>
     </array>
-    <key>NSPrivacyTrackingDomains</key>
-    <array/>
-    <key>NSPrivacyCollectedDataTypes</key>
-    <array/>
-    <key>NSPrivacyTracking</key>
-    <false/>
 </dict>
 </plist>


### PR DESCRIPTION
**起きている事象**
info.plistに記載する内容を書いていたのでエラーが出ていた模様？

このように記載すれば、SwiftData/tssのみのアプリは審査に出せた。

**プライバシーマニフェスト**　
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>NSPrivacyAccessedAPITypes</key>
    <array>
        <dict>
            <key>NSPrivacyAccessedAPIType</key>
            <string>NSUserDefaults</string>
            <key>NSPrivacyAccessedAPITypeReasons</key>
            <array>
                <string>CA92.1</string>
            </array>
        </dict>
    </array>
</dict>
</plist>
```

Info.plistの対応　
![スクリーンショット 2025-01-04 19 28 40](https://github.com/user-attachments/assets/63c7df37-5689-49ac-bb90-2a7ca77c5f25)
